### PR TITLE
Run Twitch.check_users inside an asyncio event loop

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -546,7 +546,7 @@ async def check_youtube():
 		logger.warning("yt_streamers is empty, possible initialization error: stopping.")
 		return
 
-	messages, YT_PREV_STATUS = youtube.check_users(YT_PREV_STATUS, YT_STREAMERS)
+	messages, YT_PREV_STATUS =await youtube.check_users(YT_PREV_STATUS, YT_STREAMERS)
 
 	for user_id in messages:
 

--- a/cogs/youtube.py
+++ b/cogs/youtube.py
@@ -11,7 +11,7 @@
 #
 # See the LICENSE file for more details.
 
-
+import asyncio
 import json
 import logging
 import streamlink
@@ -94,7 +94,7 @@ class Youtube(commands.Cog):
 		return status
 
 
-	def check_users(self, prev_status: Dict[str, bool], streamers: Dict[str, Dict[str, Union[str, Set[str]]]]) -> Tuple[Dict[str, List[Embed]], Dict[str, bool]]:
+	async def check_users(self, prev_status: Dict[str, bool], streamers: Dict[str, Dict[str, Union[str, Set[str]]]]) -> Tuple[Dict[str, List[Embed]], Dict[str, bool]]:
 		"""
 		Checks the status of streamers and sends a message to a determined user if the streamer just got online.
 
@@ -112,6 +112,8 @@ class Youtube(commands.Cog):
 		# }
 		messages: Dict[str, List[Embed]] = dict()
 
+		loop = asyncio.get_event_loop()
+
 		for streamer in streamers.keys():
 
 			streamer_info = streamers[streamer]
@@ -122,7 +124,7 @@ class Youtube(commands.Cog):
 			# (it does for a protected video) but I already had an error
 			# print to stdout so try/except it is.
 			try:
-				streams = streamlink.streams(channel)
+				streams = await loop.run_in_executor(None, streamlink.streams, channel)
 			except streamlink.PluginError as pe:
 				logging.getLogger('streamlink.plugin.youtube').warning("Error raised while checking a stream, skipping to next one.")
 				logging.getLogger('streamlink.plugin.youtube').debug(f"Channel: {channel}\nError:\n{pe}")


### PR DESCRIPTION
## Summary

Making the `check_users` function `async` and call the blocking `streamlink.streams` with run_with_executor

## Checklist

<!-- Replace the space inside the brackets for an x, like so: [ ] -> [x] -->

- [ ] If code changes were made, they have been tested.
  - [ ] I have updated the documentation to reflect the changes.

This PR:

- [x] fixes an issue (a patch).
- [x] adds something new, while maintaining backwards compatiblity (e.g. a new method or parameters).
- [ ] is a breaking change: backwards compatibility is **not** maintained (e.g. methods or parameters removed/renamed).
- [ ] is **not** a code change (e.g. documentation, README, etc)

